### PR TITLE
Revert to turbo:load and add turbo:submit-end

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -102,12 +102,13 @@ export default class Bridge {
       })
     }
 
-    document.addEventListener('turbo:render', renderCallback)
+    document.addEventListener('turbo:load', renderCallback)
     document.addEventListener('turbolinks:load', renderCallback)
     document.addEventListener('turbo:before-render', beforeRenderCallback)
     document.addEventListener('turbolinks:before-render', beforeRenderCallback)
     document.addEventListener('turbo:before-cache', beforeCacheCallback)
     document.addEventListener('turbolinks:before-cache', beforeCacheCallback)
     document.addEventListener('turbo:before-stream-render', beforeStreamFormRenderCallback)
+    document.addEventListener('turbo:submit-end', beforeStreamFormRenderCallback)
   }
 }


### PR DESCRIPTION
### Fixed

- Livewire and Alpine's entangle was breaking after the `turbo:load` to `turbo:render` change, so this PR adds a `requestAnimationFrame` tick before calling the `renderCallback` after the `turbo:render` event.

---

closes https://github.com/SimoTod/alpine-turbo-drive-adapter/issues/37