### PR TITLE
Update utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,9 @@ export function isValidVersion (required, current) {
     if (!currentArray[i] || currentArray[i] < requiredArray[i]) {
       return false
     }
+    else 
+    if (currentArray[i] && currentArray[i] > requiredArray[i]) {
+      return true
   }
   return true
 }


### PR DESCRIPTION
There is an error in the version checking in the utils.js. 2.4.0 is min required, but 3.2.3 will fail as 2, the second digit, is less than 4. I added logic that will simply return true if the digit is larger.